### PR TITLE
Show Token Art: Reference the specific selected token

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -150,7 +150,7 @@ Hooks.on("init", () => {
       if (!tokenActor) {
         ui.notifications.error("nothing selected!");
       } else {
-        const popout = new ImagePopout(tokenActor.data.token.texture.src, {
+        const popout = new ImagePopout(token.document.texture.src, {
           title: tokenActor.data.token.name,
           shareable: true,
           uuid: tokenActor.uuid


### PR DESCRIPTION
The Show Token Art previously referenced the prototype token which means when you changed a specific token's image path and used Show Token Art then it would show the prototype token art. Whereas if the function references the specific token then you'll get the specific image path for the token is selected.


This also means that if you assigned a wildcard image at the prototype level, the original function would return an error of image not found because it is searching for the image path including the wildcard in the query. The updated function will show the selected tokens image path. 

For instance if you have an actor with the following mapped:
`           "actor": "pf2/art/bestiary/City Guard.webp",
            "token": {
                "img":  "pf2/art/bestiary/tokens/City Guard *.webp",
                "randomImg":true
            }`
            
Previously the show token art function would return a broken image link and the following error `GET http://127.0.0.1:30000/pf2/art/bestiary/tokens/City%20Guard%20*.webp 404 (Not Found)`
