### PR TITLE
5.3.0 onwards should require PF2e 5.3.0

### DIFF
--- a/module.json
+++ b/module.json
@@ -6,7 +6,7 @@
     "minimum": "11",
     "verified": "11"
   },
-  "version": "5.0.0",
+  "version": "5.3.2",
   "authors": [
     {
       "name": "DrentalBot",

--- a/module.json
+++ b/module.json
@@ -21,11 +21,11 @@
       "id": "pf2e",
       "type": "system",
       "compatibility": {
-        "minimum": "5.0.0-beta1"
+        "minimum": "5.3.0"
       }
     }]
   },
   "url": "https://github.com/Drental/foundryvtt-pf2e-f-is-for-flatfooted",
-  "download":"https://github.com/Drental/foundryvtt-pf2e-f-is-for-flatfooted/releases/download/5.0.0/module.zip",
+  "download":"https://github.com/Drental/foundryvtt-pf2e-f-is-for-flatfooted/releases/latest/download/module.zip",
   "manifest":"https://github.com/Drental/foundryvtt-pf2e-f-is-for-flatfooted/releases/latest/download/module.json"
 }


### PR DESCRIPTION
F for off-guard won't work on <5.3.0 PF2e systems